### PR TITLE
Add sassy AI Discord bot implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# Lurk.AI-Discord-Bot
+# Lurk AI Discord Bot
+
+An opinionated Discord chatbot that leans into a "sassy-but-kind, chaotically smart" persona. The bot listens for direct mentions (or DMs) and responds using OpenAI's Chat Completion API while keeping a short rolling conversation memory per channel.
+
+## Features
+
+- **Custom Persona** – Carefully crafted system prompt to keep responses sharp, witty, and supportive.
+- **Conversation Memory** – Maintains the last few user/assistant exchanges per channel for coherent replies.
+- **Opt-in Responses** – Replies to DMs, direct mentions, or message replies to the bot.
+- **Reset Command** – Use `!reset` to clear the stored history for a channel.
+
+## Getting Started
+
+### 1. Clone & Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2. Configure Environment
+
+Create a `.env` file (or export the variables another way) with:
+
+```env
+DISCORD_TOKEN=your_discord_bot_token
+OPENAI_API_KEY=your_openai_key
+OPENAI_MODEL=gpt-3.5-turbo  # optional override
+MAX_CONTEXT_TURNS=6          # optional
+OPENAI_TEMPERATURE=0.8       # optional
+SYSTEM_DIRECTIVES=extra rule one||another directive  # optional, use || as separator
+```
+
+### 3. Run the Bot
+
+```bash
+python -m lurk_bot.bot
+```
+
+`python-dotenv` automatically loads the `.env` file when the bot starts, so no manual exporting is required unless you prefer it.
+
+Invite the bot to your server, mention it, and enjoy the chaotic brainpower.
+
+## Development Notes
+
+- The project uses an in-memory conversation store; restarting the bot clears history.
+- Error handling is intentionally light—check the console logs for stack traces when things break.
+- Feel free to tweak the persona in `src/lurk_bot/persona.py` to better match your vibe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lurk-bot"
+version = "0.1.0"
+description = "Discord chatbot with a sassy chaotic persona"
+authors = [{ name = "Lurk" }]
+requires-python = ">=3.10"
+dependencies = [
+    "discord.py>=2.3.2,<3",
+    "openai>=0.27,<1",
+    "python-dotenv>=1.0,<2",
+]
+
+[project.optional-dependencies]
+dev = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py>=2.3.2,<3
+openai>=0.27,<1
+python-dotenv>=1.0,<2

--- a/src/lurk_bot/__init__.py
+++ b/src/lurk_bot/__init__.py
@@ -1,0 +1,7 @@
+"""Lurk AI Discord bot package."""
+
+from .bot import LurkBot, main, run_bot
+from .config import Settings
+from .persona import build_system_message
+
+__all__ = ["LurkBot", "main", "run_bot", "Settings", "build_system_message"]

--- a/src/lurk_bot/bot.py
+++ b/src/lurk_bot/bot.py
@@ -1,0 +1,128 @@
+"""Discord bot implementation for the Lurk AI assistant."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+from .config import Settings
+from .llm import ChatModel
+from .memory import ConversationMemory
+
+
+log = logging.getLogger(__name__)
+
+
+class LurkBot(commands.Bot):
+    """Custom Discord bot wired to an OpenAI chat model."""
+
+    def __init__(self, settings: Settings) -> None:
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.members = False
+        intents.presences = False
+
+        super().__init__(command_prefix=commands.when_mentioned_or("!"), intents=intents)
+        self.settings = settings
+        self.chat_model = ChatModel(
+            api_key=settings.openai_api_key,
+            model=settings.openai_model,
+            temperature=settings.temperature,
+            system_directives=settings.system_directives,
+        )
+        self.memory = ConversationMemory(max_turns=settings.max_context_turns)
+
+    async def setup_hook(self) -> None:
+        await self.add_cog(ChatCog(self))
+
+
+class ChatCog(commands.Cog):
+    """Cog that listens for messages and routes them to the language model."""
+
+    def __init__(self, bot: LurkBot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        log.info("Logged in as %s (%s)", self.bot.user, self.bot.user and self.bot.user.id)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        # Ignore the bot's own messages or other bots.
+        if message.author.bot:
+            return
+
+        if not await self._should_respond(message):
+            return
+
+        channel_id = message.channel.id
+        content = message.content.strip()
+
+        # Store the user message in history prior to response generation.
+        self.bot.memory.append_user_only(channel_id, content)
+
+        async with message.channel.typing():
+            try:
+                history = self.bot.memory.iter_history(channel_id)
+                response = await self.bot.chat_model.generate_reply(history, content)
+            except Exception as exc:  # pragma: no cover - best-effort logging
+                log.exception("Error while generating response: %s", exc)
+                await message.reply(
+                    "My brain just tripped over its own shoelaces. Give me a sec and try again."
+                )
+                return
+
+        # Save the assistant response and send it.
+        self.bot.memory.append_assistant_only(channel_id, response)
+        await message.reply(response, mention_author=False)
+
+    async def _should_respond(self, message: discord.Message) -> bool:
+        """Check whether the bot should respond to this message."""
+
+        if isinstance(message.channel, discord.DMChannel):
+            return True
+
+        if not self.bot.user:
+            return False
+
+        mentioned = any(user.id == self.bot.user.id for user in message.mentions)
+        reply_to_bot = message.reference and isinstance(message.reference.resolved, discord.Message)
+        if reply_to_bot and message.reference.resolved.author == self.bot.user:
+            return True
+        return mentioned
+
+    @commands.command(name="reset")
+    async def reset_history(self, ctx: commands.Context) -> None:
+        """Slash-style command to clear the channel's stored conversation."""
+
+        self.bot.memory.clear(ctx.channel.id)
+        await ctx.reply("Alright, fresh slate. What chaos are we conjuring now?", mention_author=False)
+
+
+async def run_bot() -> None:
+    """Entrypoint for running the bot from an async context."""
+
+    load_dotenv()
+    settings = Settings.from_env()
+    bot = LurkBot(settings)
+
+    async with bot:
+        await bot.start(settings.discord_token)
+
+
+def main() -> None:
+    """Synchronous wrapper used when running via ``python -m``."""
+
+    logging.basicConfig(level=logging.INFO)
+    try:
+        asyncio.run(run_bot())
+    except KeyboardInterrupt:  # pragma: no cover - interactive signal
+        log.info("Bot shutdown requested by user")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lurk_bot/config.py
+++ b/src/lurk_bot/config.py
@@ -1,0 +1,65 @@
+"""Configuration helpers for environment-driven settings."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Settings:
+    """Container for runtime configuration values."""
+
+    discord_token: str
+    openai_api_key: str
+    openai_model: str = "gpt-3.5-turbo"
+    system_directives: tuple[str, ...] = ()
+    max_context_turns: int = 6
+    temperature: float = 0.8
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Load settings from environment variables."""
+
+        discord_token = os.environ.get("DISCORD_TOKEN")
+        if not discord_token:
+            raise RuntimeError("DISCORD_TOKEN environment variable is required")
+
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_api_key:
+            raise RuntimeError("OPENAI_API_KEY environment variable is required")
+
+        model = os.environ.get("OPENAI_MODEL", cls.openai_model)
+        max_turns_str = os.environ.get("MAX_CONTEXT_TURNS")
+        temperature_str = os.environ.get("OPENAI_TEMPERATURE")
+        extra = tuple(
+            directive.strip()
+            for directive in os.environ.get("SYSTEM_DIRECTIVES", "").split("||")
+            if directive.strip()
+        )
+
+        max_turns = cls.max_context_turns
+        if max_turns_str:
+            try:
+                max_turns = max(1, int(max_turns_str))
+            except ValueError as exc:
+                raise RuntimeError("MAX_CONTEXT_TURNS must be an integer") from exc
+
+        temperature = cls.temperature
+        if temperature_str:
+            try:
+                temperature = float(temperature_str)
+            except ValueError as exc:
+                raise RuntimeError("OPENAI_TEMPERATURE must be a float") from exc
+
+        return cls(
+            discord_token=discord_token,
+            openai_api_key=openai_api_key,
+            openai_model=model,
+            system_directives=extra,
+            max_context_turns=max_turns,
+            temperature=temperature,
+        )
+
+
+__all__ = ["Settings"]

--- a/src/lurk_bot/llm.py
+++ b/src/lurk_bot/llm.py
@@ -1,0 +1,37 @@
+"""Wrapper around the OpenAI chat completion API."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import openai
+
+from .persona import build_system_message
+from .memory import RoleContentPair
+
+
+class ChatModel:
+    """A minimal wrapper for invoking OpenAI's chat completion endpoint."""
+
+    def __init__(self, *, api_key: str, model: str, temperature: float, system_directives: Sequence[str] | None = None) -> None:
+        openai.api_key = api_key
+        self.model = model
+        self.temperature = temperature
+        self.system_message = build_system_message(list(system_directives or []))
+
+    async def generate_reply(self, history: Iterable[RoleContentPair], user_message: str) -> str:
+        """Produce a chat completion from the provided context."""
+
+        messages = [{"role": "system", "content": self.system_message}]
+        messages.extend({"role": role, "content": content} for role, content in history)
+        messages.append({"role": "user", "content": user_message})
+
+        response = await openai.ChatCompletion.acreate(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+        )
+        return response.choices[0].message["content"].strip()
+
+
+__all__ = ["ChatModel"]

--- a/src/lurk_bot/memory.py
+++ b/src/lurk_bot/memory.py
@@ -1,0 +1,63 @@
+"""In-memory conversation history for the Discord bot."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Iterable, List, Tuple
+
+
+RoleContentPair = Tuple[str, str]
+
+
+@dataclass
+class ConversationMemory:
+    """Stores the rolling conversation history per channel.
+
+    The memory keeps a fixed number of message pairs (user + assistant)
+    so the prompt remains within the model's context window.
+    """
+
+    max_turns: int = 6
+
+    def __post_init__(self) -> None:
+        self._history: Dict[int, Deque[RoleContentPair]] = defaultdict(deque)
+
+    def append_exchange(self, channel_id: int, user: str, assistant: str) -> None:
+        """Add a new user/assistant pair to the conversation history."""
+
+        history = self._history[channel_id]
+        history.append(("user", user))
+        history.append(("assistant", assistant))
+
+        # Trim the history to the most recent ``max_turns`` user+assistant pairs.
+        while len(history) > self.max_turns * 2:
+            history.popleft()
+            history.popleft()
+
+    def append_user_only(self, channel_id: int, user: str) -> None:
+        """Add a user message when we have not yet responded."""
+
+        self._history[channel_id].append(("user", user))
+        while len(self._history[channel_id]) > self.max_turns * 2:
+            self._history[channel_id].popleft()
+
+    def append_assistant_only(self, channel_id: int, assistant: str) -> None:
+        """Add an assistant message when seeded from outside the bot."""
+
+        self._history[channel_id].append(("assistant", assistant))
+        while len(self._history[channel_id]) > self.max_turns * 2:
+            self._history[channel_id].popleft()
+
+    def clear(self, channel_id: int) -> None:
+        """Remove the stored history for a given channel."""
+
+        self._history.pop(channel_id, None)
+
+    def iter_history(self, channel_id: int) -> Iterable[RoleContentPair]:
+        """Yield the history for the given channel in chronological order."""
+
+        return list(self._history.get(channel_id, ()))
+
+
+__all__: List[str] = ["ConversationMemory", "RoleContentPair"]

--- a/src/lurk_bot/persona.py
+++ b/src/lurk_bot/persona.py
@@ -1,0 +1,32 @@
+"""Prompt engineering helpers for the Lurk AI persona."""
+
+from __future__ import annotations
+
+from typing import List
+
+SYSTEM_PROMPT = (
+    "You are Lurk, an AI sidekick who embodies your creator's voice: "
+    "sassy yet kind, razor-sharp smart, and chaotically clever. "
+    "You delight in witty banter, balancing playful roasts with genuine support. "
+    "Always be helpful, but do it with flair, clever metaphors, and fearless honesty. "
+    "You use casual modern language, contractions, and conversational rhythm. "
+    "You never dunk on the user cruelly; your sass comes with warmth and encouragement."
+)
+
+SAFETY_REMINDERS = (
+    "Keep responses concise unless the user asks for depth. "
+    "Steer clear of explicit content, hate, or harassment. "
+    "If the user requests something unsafe or disallowed, refuse with empathy and humor."
+)
+
+
+def build_system_message(extra_directives: List[str] | None = None) -> str:
+    """Compose the system message that guides the model's behavior."""
+
+    directives = [SYSTEM_PROMPT, SAFETY_REMINDERS]
+    if extra_directives:
+        directives.extend(extra_directives)
+    return "\n".join(directives)
+
+
+__all__ = ["build_system_message"]


### PR DESCRIPTION
## Summary
- add an OpenAI-powered Discord bot with a sassy-but-kind persona and rolling conversation memory
- provide environment-driven configuration, persona helpers, and packaging metadata
- document setup instructions, dependencies, and add ignores for local artifacts

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d553059eb88327ac1c91e7f0ba8e8d